### PR TITLE
Add Selenium UI testing workflow

### DIFF
--- a/.github/workflows/ui-testing.yaml
+++ b/.github/workflows/ui-testing.yaml
@@ -31,7 +31,12 @@ on:
 jobs:
   selenium-tests:
     runs-on: ubuntu-latest
-    
+    env:
+      ENVIRONMENT: ${{ github.event.inputs.environment || 'staging' }}
+      BROWSER: ${{ github.event.inputs.browser || 'chrome' }}
+      HEADLESS: "true"
+      OLLAMA_URL: 'http://<EC2_PUBLIC_IP>:3000'  # Replace with your actual public IP
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
@@ -69,10 +74,6 @@ jobs:
         sudo mv chromedriver-linux64/chromedriver /usr/local/bin/chromedriver
         sudo chmod +x /usr/local/bin/chromedriver
 
-
-    - name: Run Selenium tests
-      env:
-        HEADLESS: true
-        OLLAMA_URL: http://EC2_PUBLIC_IP:3000  # Replace with your actual public IP
-      run: |
-        pytest tests/ -v
+      - name: Run Selenium tests
+        run: |
+          pytest tests/ -v


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run Selenium UI tests on pull requests
- allow environment and browser selection for manual dispatch
- install Chrome/ChromeDriver and execute pytest-based tests

## Testing
- `npx --yes actionlint@latest .github/workflows/ui-testing.yaml` *(failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68961dcbecd8832a82e86edf2db62d9c